### PR TITLE
Possible name and description for uBlockOrigin list 

### DIFF
--- a/url_list.txt
+++ b/url_list.txt
@@ -1,3 +1,6 @@
+! Title: Anti-Grabify for uBO
+! Description: This filter uses the rules from the Anti-Grabify extension to block all the IP grabber links that the Grabify service currently uses.
+
 grabify.link/*
 grabify.link/*
 bmwforum.co/*


### PR DESCRIPTION
Currently, when the list is added, it just shows the URL as its name. This pull proposes a name and a description for the list in uBlock Origin. You, of course, may change them as you will.

For some reason, linkify.me/* is shown to have been changed, when I didn't.