### PR TITLE
Add ip-trap.com domains

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Anti-Grabify",
-  "version": "2.1",
+  "version": "2.2",
   "manifest_version": 3,
   "description": "Blocks IP grabbers from Grabify and other IP grabber links.",
   "background": {

--- a/chrome/other-urls.json
+++ b/chrome/other-urls.json
@@ -4,5 +4,7 @@
     { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":3,"priority": 1, "condition" : {"urlFilter" : "||xn--yutube-iq4b.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
     { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":4,"priority": 1, "condition" : {"urlFilter" : "||gyazo.nl/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
     { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":5,"priority": 1, "condition" : {"urlFilter" : "||goo.by/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
-    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":6,"priority": 1, "condition" : {"urlFilter" : "||ikwyd.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}}
+    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":6,"priority": 1, "condition" : {"urlFilter" : "||ikwyd.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
+    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":7,"priority": 1, "condition" : {"urlFilter" : "||ip-trap.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
+    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":8,"priority": 1, "condition" : {"urlFilter" : "||ythingy.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}}
 ]

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -24,7 +24,7 @@ a {
   </style>
 </head>
 <body>
-<div style="width:275px"><strong>Anti-Grabify</strong> (<small>Version 2.1</small>)</div>
+<div style="width:275px"><strong>Anti-Grabify</strong> (<small>Version 2.2</small>)</div>
 <div>
 <a href="https://github.com/konnor88/anti-grabify" target="_blank">GitHub</a> |
 <a href="https://twitter.com/AntiGrabify" target="_blank">Twitter</a> |

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Anti-Grabify",
-  "version": "2.1",
+  "version": "2.2",
   "manifest_version": 3,
   "description": "Blocks IP grabbers from Grabify and other IP grabber links.",
   "background": {

--- a/edge/other-urls.json
+++ b/edge/other-urls.json
@@ -4,5 +4,7 @@
     { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":3,"priority": 1, "condition" : {"urlFilter" : "||xn--yutube-iq4b.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
     { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":4,"priority": 1, "condition" : {"urlFilter" : "||gyazo.nl/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
     { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":5,"priority": 1, "condition" : {"urlFilter" : "||goo.by/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
-    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":6,"priority": 1, "condition" : {"urlFilter" : "||ikwyd.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}}
+    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":6,"priority": 1, "condition" : {"urlFilter" : "||ikwyd.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
+    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":7,"priority": 1, "condition" : {"urlFilter" : "||ip-trap.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}},
+    { "action":{"type":"block"},"isUrlFilterCaseSensitive":false, "id":8,"priority": 1, "condition" : {"urlFilter" : "||ythingy.com/*", "resourceTypes" : ["websocket", "main_frame","script", "ping"]}}
 ]

--- a/edge/popup.html
+++ b/edge/popup.html
@@ -24,7 +24,7 @@ a {
   </style>
 </head>
 <body>
-<div style="width:275px"><strong>Anti-Grabify</strong> (<small>Version 2.1</small>)</div>
+<div style="width:275px"><strong>Anti-Grabify</strong> (<small>Version 2.2</small>)</div>
 <div>
 <a href="https://github.com/konnor88/anti-grabify" target="_blank">GitHub</a> |
 <a href="https://twitter.com/AntiGrabify" target="_blank">Twitter</a> |

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -55,7 +55,9 @@ browser.webRequest.onBeforeRequest.addListener(
         "*://yȯutube.com/*",
         "*://gyazo.nl/*",
         "*://goo.by/*",
-        "*://ikwyd.com/*"
+        "*://ikwyd.com/*",
+        "*://ip-trap.com/*",
+        "*://ythingy.com/*"
     ]},
     ["blocking"]
 );

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Anti-Grabify",
-  "version": "1.16",
+  "version": "1.17",
   "manifest_version": 2,
   "description": "Blocks IP grabbers from Grabify and other IP grabber links.",
   "background": {

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -24,7 +24,7 @@ a {
   </style>
 </head>
 <body>
-<div style="width:275px"><strong>Anti-Grabify</strong> (<small>Version 1.16</small>)</div>
+<div style="width:275px"><strong>Anti-Grabify</strong> (<small>Version 1.17</small>)</div>
 <div>
 <a href="https://github.com/konnor88/anti-grabify" target="_blank">GitHub</a> |
 <a href="https://twitter.com/AntiGrabify" target="_blank">Twitter</a> |

--- a/url_list.txt
+++ b/url_list.txt
@@ -56,3 +56,5 @@ yȯutube.com/*
 gyazo.nl/*
 goo.by/*
 ikwyd.com/*
+ip-trap.com/*
+ythingy.com/*


### PR DESCRIPTION
To my surprise, the site is still operational.
This adds the domains `ip-trap.com` and `ythingy.com`, the latter being used to acquire the IP of users.